### PR TITLE
修正README中的awk错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Simple Recommendation Web Service
 
 使用Movielens 1M数据，从 http://www.grouplens.org/node/12 下载并解压。然后将ratings.dat文件转换一下，参考如下命令。
 
-    $ awk -F '::' '{printf "%s\t%s\t%s\n", $1, $2, $3}' ratings.dat > romar.log.0
+    $ awk -F '::' '{printf "%s,%s,%s\n", $1, $2, $3}' ratings.dat > romar.log.0
 
 将生成的文件`romar.log.0`放入`$ROMAR_HOME/data`目录里。
 


### PR DESCRIPTION
修正README中的awk错误，分割符由\t改成逗号。
