### PR TITLE
优化日志输出

### DIFF
--- a/conf/log4j.xml
+++ b/conf/log4j.xml
@@ -2,15 +2,19 @@
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-	<appender name="ROMAR" class="org.apache.log4j.FileAppender">
-		<param name="File" value="${romar.home}/logs/romar.log" />
+    <appender name="ROMAR" class="org.apache.log4j.DailyRollingFileAppender">
+        <param name="File" value="${romar.home}/logs/romar.log" />
+        <param name="DatePattern" value=".yyyy-MM-dd" />
         <param name="Append" value="true" />
         <layout class="org.apache.log4j.PatternLayout">
-	        <param name="ConversionPattern" value="%-5p %d [%t] %c{1} - %m%n" />
-	    </layout>
+            <param name="ConversionPattern" value="%-5p %d [%t] %c{1} - %m%n" />
+        </layout>
     </appender>
 
     <logger name="com.anjuke">
+        <level value="info" />
+    </logger>
+    <logger name="com.anjuke.romar.http.rest">
         <level value="info" />
     </logger>
     <logger name="org.apache.mahout.cf.taste.impl.common">

--- a/src/main/java/com/anjuke/romar/http/rest/BaseResource.java
+++ b/src/main/java/com/anjuke/romar/http/rest/BaseResource.java
@@ -39,9 +39,11 @@ abstract class BaseResource {
 
     protected final RomarCore _romarCore = CoreContainer.getCore();
 
-    private final boolean _allowUserStringID = RomarConfig.getInstance().isAllowUserStringID();
+    private final boolean _allowUserStringID = RomarConfig.getInstance()
+            .isAllowUserStringID();
 
-    private final boolean _allowItemStringID = RomarConfig.getInstance().isAllowItemStringID();
+    private final boolean _allowItemStringID = RomarConfig.getInstance()
+            .isAllowItemStringID();
 
     long[] getItemIds(List<String> itemStrings) {
         try {
@@ -56,8 +58,12 @@ abstract class BaseResource {
                 }
             }
             return items;
+        } catch (InternalException e) {
+            throw e;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (log.isDebugEnabled()) {
+                log.error(e.getMessage(), e);
+            }
             throw new InternalException(new ErrorResponse(ErrorResponse.INTERNAL_ERROR,
                     "internal error: " + e.getMessage()));
         }
@@ -86,8 +92,12 @@ abstract class BaseResource {
     String getItemString(long item) {
         try {
             return _romarCore.getItemIdMigrator().toStringID(item);
+        } catch (InternalException e) {
+            throw e;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (log.isDebugEnabled()) {
+                log.error(e.getMessage(), e);
+            }
             throw new InternalException(new ErrorResponse(ErrorResponse.INTERNAL_ERROR,
                     "internal error: " + e.getMessage()));
         }
@@ -96,24 +106,32 @@ abstract class BaseResource {
     String getUserString(long user) {
         try {
             return _romarCore.getUserIdMigrator().toStringID(user);
+        } catch (InternalException e) {
+            throw e;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (log.isDebugEnabled()) {
+                log.error(e.getMessage(), e);
+            }
             throw new InternalException(new ErrorResponse(ErrorResponse.INTERNAL_ERROR,
                     "internal error: " + e.getMessage()));
         }
     }
 
     long getItem(String itemString) {
-        long item;
         try {
+            long item;
             if (_allowItemStringID) {
                 item = _romarCore.getItemIdMigrator().toLongID(itemString);
             } else {
                 item = Long.parseLong(itemString);
             }
             return item;
+        } catch (InternalException e) {
+            throw e;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (log.isDebugEnabled()) {
+                log.error(e.getMessage(), e);
+            }
             throw new InternalException(new ErrorResponse(ErrorResponse.INTERNAL_ERROR,
                     "internal error: " + e.getMessage()));
         }
@@ -128,8 +146,12 @@ abstract class BaseResource {
                 user = Long.parseLong(userString);
             }
             return user;
+        } catch (InternalException e) {
+            throw e;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (log.isDebugEnabled()) {
+                log.error(e.getMessage(), e);
+            }
             throw new InternalException(new ErrorResponse(ErrorResponse.INTERNAL_ERROR,
                     "internal error: " + e.getMessage()));
         }
@@ -151,8 +173,12 @@ abstract class BaseResource {
                 item = Long.parseLong(itemString);
             }
             return new long[] {user, item};
+        } catch (InternalException e) {
+            throw e;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (log.isDebugEnabled()) {
+                log.error(e.getMessage(), e);
+            }
             throw new InternalException(new ErrorResponse(ErrorResponse.INTERNAL_ERROR,
                     "internal error: " + e.getMessage()));
         }
@@ -167,8 +193,12 @@ abstract class BaseResource {
                     result.add(getUserString(userId));
                 }
                 return new MultiValueResponse(result);
+            } catch (InternalException e) {
+                throw e;
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                if (log.isDebugEnabled()) {
+                    log.error(e.getMessage(), e);
+                }
                 throw new InternalException(
                         new ErrorResponse(ErrorResponse.INTERNAL_ERROR,
                                 "internal error: " + e.getMessage()));

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -12,6 +12,10 @@
     <logger name="com.anjuke">
         <level value="info" />
     </logger>
+
+    <logger name="com.anjuke.romar.http.rest">
+        <level value="debug" />
+    </logger>
     <logger name="org.apache.mahout.cf.taste.impl.common">
         <level value="warn" />
     </logger>


### PR DESCRIPTION
jersey接口的几个类里，日志是否输出判断降级到debug

在log4j.xml里增加一项
<logger name="com.anjuke.romar.http.rest">
        <level value="info" />
</logger>
通过次参数调整日志输出的等级
